### PR TITLE
python2 removal / salt upgrade

### DIFF
--- a/salt/elife-libraries/init.sls
+++ b/salt/elife-libraries/init.sls
@@ -133,4 +133,4 @@ tox:
     cmd.run:
         - name: pip install "tox==2.9.1"
         - require:
-            - global-python-requisites
+            - python-3


### PR DESCRIPTION
* `global-python-requisites` is deprecated and depends on python2
* blocked by this: https://github.com/saltstack/salt/issues/55811 which is only replicated when using 2018.3