### PR TITLE
Salt 2018.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-elifeFormula('elife-libraries', '', null, ['s1604'])
+elifeFormula('elife-libraries', '', null, ['standalone-next-salt'])


### PR DESCRIPTION
* adds next-salt alt config to Jenkinsfile
* this version of salt is known to work with elife-libraries, but not when python3 is used to run bootstrap