### PR TITLE
adds 'elife-cleaner' dependencies to list

### DIFF
--- a/salt/elife-libraries/config/etc-ImageMagick-6-policy.xml
+++ b/salt/elife-libraries/config/etc-ImageMagick-6-policy.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)+>
+<!ELEMENT policy (#PCDATA)>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only.  We use a glob
+  expression to match all paths that start with /repository:
+  
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Let's prevent possible exploits by removing the right to use indirect reads.
+
+    <policy domain="path" rights="none" pattern="@*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1GB"/>
+
+  Define arguments for the memory, map, area, width, height, and disk resources
+  with SI prefixes (.e.g 100MB).  In addition, resource policies are maximums
+  for each instance of ImageMagick (e.g. policy memory limit 1GB, -limit 2GB
+  exceeds policy maximum so memory limit is 1GB).
+-->
+<policymap>
+  <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
+  <policy domain="resource" name="memory" value="256MiB"/>
+  <policy domain="resource" name="map" value="512MiB"/>
+  <policy domain="resource" name="width" value="16KP"/>
+  <policy domain="resource" name="height" value="16KP"/>
+  <policy domain="resource" name="area" value="128MB"/>
+  <policy domain="resource" name="disk" value="1GiB"/>
+  <!-- <policy domain="resource" name="file" value="768"/> -->
+  <!-- <policy domain="resource" name="thread" value="4"/> -->
+  <!-- <policy domain="resource" name="throttle" value="0"/> -->
+  <!-- <policy domain="resource" name="time" value="3600"/> -->
+  <!-- <policy domain="system" name="precision" value="6"/> -->
+  <!-- not needed due to the need to use explicitly by mvg: -->
+  <!-- <policy domain="delegate" rights="none" pattern="MVG" /> -->
+  <!-- use curl -->
+  <policy domain="delegate" rights="none" pattern="URL" />
+  <policy domain="delegate" rights="none" pattern="HTTPS" />
+  <policy domain="delegate" rights="none" pattern="HTTP" />
+  <!-- in order to avoid to get image with password text -->
+  <policy domain="path" rights="none" pattern="@*"/>
+  <policy domain="cache" name="shared-secret" value="passphrase" stealth="true"/>
+  <!-- disable ghostscript format types -->
+  <policy domain="coder" rights="none" pattern="PS" />
+  <policy domain="coder" rights="none" pattern="PS2" />
+  <policy domain="coder" rights="none" pattern="PS3" />
+  <policy domain="coder" rights="none" pattern="EPS" />
+
+  <!-- lsh@2021-05-25: changed rights="none" to rights="read|write" -->
+  <policy domain="coder" rights="read|write" pattern="PDF" />
+
+  <policy domain="coder" rights="none" pattern="XPS" />
+</policymap>

--- a/salt/elife-libraries/init.sls
+++ b/salt/elife-libraries/init.sls
@@ -17,33 +17,27 @@ pattern-library-gulp:
         - require:
             - pkg: nodejs
 
-make:
-    pkg.installed
-
-# pattern-library use to depend on `gem install` but it has since been moved to containers and eventually removed.
-# remove when 16.04 no longer supported
-{% if salt['grains.get']('osrelease') == '16.04' %}
-ruby-dev:
-    pkg.installed
-{% endif %}
-
-elife-poa-xml-generation-dependencies:
+project-dependencies:
     pkg.installed:
         - pkgs:
+            - make
+            # elife-poa-xml-generation
             - libxml2-dev
             - libxslt1-dev
-
-article-json bot-lax elife-tools dependencies:
-    pkg.installed:
-        - pkgs:
+            # article-json, bot-lax, elife-tools
             - libxml2-dev
             - libxslt1-dev
-
-elife-metrics-dependencies:
-    pkg.installed:
-        - pkgs:
+            # elife-metrics
             - libffi-dev
             - libpq-dev
+            # cleaner
+            - ghostscript
+            - libmagickwand-dev
+
+imagemagick-policy:
+    file.managed:
+        - name: /etc/ImageMagick-6/policy.xml
+        - source: salt://elife-libraries/config/etc-ImageMagick-6-policy.xml
 
 elife-metrics-auth:
     file.managed:


### PR DESCRIPTION
consolidated dependencies into a single list
removed some Ubuntu 16.04 logic

depends on: https://github.com/elifesciences/builder-base-formula/pull/306