### PR TITLE
adds builder.sls that install builder, copied from elife-alfred.

### DIFF
--- a/salt/elife-libraries/builder.sls
+++ b/salt/elife-libraries/builder.sls
@@ -51,7 +51,7 @@ builder-update:
             - builder-project
 
     cmd.run:
-        - name: ./update.sh --exclude virtualbox vagrant ssh-agent ssh-credentials vault
+        - name: ./update.sh --exclude virtualbox vagrant ssh-agent ssh-credentials vault terraform
         - cwd: /srv/builder
         - runas: {{ pillar.elife.deploy_user.username }}
         - require:

--- a/salt/elife-libraries/builder.sls
+++ b/salt/elife-libraries/builder.sls
@@ -29,9 +29,6 @@ builder-project:
         - force_reset: True
         - target: /srv/builder
         - require:
-            #- srv-directory-linked
-            #- builder-project-aws-credentials-elife
-            #- builder-project-aws-credentials-jenkins
             - builder-project-dependencies
 
     file.directory:
@@ -55,12 +52,11 @@ builder-update:
         - cwd: /srv/builder
         - runas: {{ pillar.elife.deploy_user.username }}
         - require:
-            #- builder-project-aws-credentials-elife
-            #- builder-project-aws-credentials-jenkins
+            - aws-credentials-deploy-user # builder-base.aws-credentials
             - file: builder-update
 
 builder-logrotate:
     file.managed:
         - name: /etc/logrotate.d/builder
-        - source: salt://elife-alfred/config/etc-logrotate.d-builder
+        - source: salt://elife-libraries/config/etc-logrotate.d-builder
 

--- a/salt/elife-libraries/builder.sls
+++ b/salt/elife-libraries/builder.sls
@@ -1,0 +1,66 @@
+# lsh@2023-03-28: extracted from elife-alfred/init.sls
+
+builder-non-interactive:
+    file.append:
+        - name: /etc/environment
+        - text: "BUILDER_NON_INTERACTIVE=1"
+        - unless:
+            - grep 'BUILDER_NON_INTERACTIVE=1' /etc/environment
+
+builder-highstate-no-colours:
+    file.append:
+        - name: /etc/environment
+        - text: "SALT_NO_COLOR=1"
+        - unless:
+            - grep 'SALT_NO_COLOR=1' /etc/environment
+
+builder-project-dependencies:
+    pkg.installed:
+        - pkgs:
+            - make
+            - gcc
+
+builder-project:
+    builder.git_latest:
+        - name: ssh://git@github.com/elifesciences/builder.git
+        - identity: {{ pillar.elife.projects_builder.key or '' }}
+        - rev: master
+        - force_fetch: True
+        - force_reset: True
+        - target: /srv/builder
+        - require:
+            #- srv-directory-linked
+            #- builder-project-aws-credentials-elife
+            #- builder-project-aws-credentials-jenkins
+            - builder-project-dependencies
+
+    file.directory:
+        - name: /srv/builder
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - recurse:
+            - user
+            - group
+        - require:
+            - builder: builder-project
+
+builder-update:
+    file.touch:
+        - name: /srv/builder/.no-delete-venv.flag
+        - require:
+            - builder-project
+
+    cmd.run:
+        - name: ./update.sh --exclude virtualbox vagrant ssh-agent ssh-credentials vault
+        - cwd: /srv/builder
+        - runas: {{ pillar.elife.deploy_user.username }}
+        - require:
+            #- builder-project-aws-credentials-elife
+            #- builder-project-aws-credentials-jenkins
+            - file: builder-update
+
+builder-logrotate:
+    file.managed:
+        - name: /etc/logrotate.d/builder
+        - source: salt://elife-alfred/config/etc-logrotate.d-builder
+

--- a/salt/elife-libraries/config/etc-logrotate.d-builder
+++ b/salt/elife-libraries/config/etc-logrotate.d-builder
@@ -1,0 +1,8 @@
+/srv/builder/logs/*.log {
+    daily
+    missingok
+    rotate 7
+    compress
+    delaycompress
+    notifempty
+}

--- a/salt/elife-libraries/config/etc-ubr-test-app.cfg
+++ b/salt/elife-libraries/config/etc-ubr-test-app.cfg
@@ -1,7 +1,6 @@
-{% set app = pillar.elife_libraries %}
 [mysql]
-user={{ app.mysql.user }}
-pass={{ app.mysql.pass }}
+user={{ pillar.elife_libraries.mysql.user }}
+pass={{ pillar.elife_libraries.mysql.pass }}
 host=localhost
 port=3306
 
@@ -9,5 +8,5 @@ port=3306
 user=root
 
 [aws]
-access_key_id={{ app.aws.access_key_id }}
-secret_access_key={{ app.aws.secret_access_key }}
+access_key_id={{ pillar.elife.aws.access_key_id }}
+secret_access_key={{ pillar.elife.aws.secret_access_key }}

--- a/salt/elife-libraries/config/home-deploy-user-.aws-credentials
+++ b/salt/elife-libraries/config/home-deploy-user-.aws-credentials
@@ -1,4 +1,0 @@
-[default]
-aws_secret_access_key = {{ pillar.elife_libraries.aws.secret_access_key }}
-aws_access_key_id = {{ pillar.elife_libraries.aws.access_key_id }}
-region = {{ pillar.elife_libraries.aws.region }}

--- a/salt/elife-libraries/init.sls
+++ b/salt/elife-libraries/init.sls
@@ -97,17 +97,6 @@ cached-repositories-link:
         - require:
             - cached-repositories
 
-aws-credentials:
-    file.managed:
-        - name: /home/{{ pillar.elife.deploy_user.username }}/.aws/credentials
-        - source: salt://elife-libraries/config/home-deploy-user-.aws-credentials
-        - template: jinja
-        - makedirs: True
-        - user: {{ pillar.elife.deploy_user.username }}
-        - group: {{ pillar.elife.deploy_user.username }}
-        - require:
-            - deploy-user
-
 mysql-user:
     mysql_user.present:
         - name: elife-libraries

--- a/salt/example.top
+++ b/salt/example.top
@@ -5,6 +5,7 @@ base:
         - elife.php7
         - elife.composer
         - elife.nodejs16
+        - elife.aws-credentials
         - elife.aws-cli
         - elife.external-volume
         - elife.mysql-client
@@ -20,3 +21,4 @@ base:
         - elife-libraries
         #- elife.external-volume-srv
         #- elife.spectrum
+        - elife-libraries.builder

--- a/salt/pillar/elife-libraries.sls
+++ b/salt/pillar/elife-libraries.sls
@@ -1,8 +1,10 @@
-elife_libraries:
+elife:
     aws:
         secret_access_key: null
         access_key_id: null
         region: us-east-1
+
+elife_libraries:
     mysql:
         user: elife-libraries
         pass: elife-libraries


### PR DESCRIPTION
replaces aws-credentials state with elife.aws-credentials. updates pillar data accordingly