### PR TITLE
project-dependencies, fixes duplicate package names.

### DIFF
--- a/salt/elife-libraries/init.sls
+++ b/salt/elife-libraries/init.sls
@@ -39,8 +39,8 @@ project-dependencies:
             - libxml2-dev
             - libxslt1-dev
             # article-json, bot-lax, elife-tools
-            - libxml2-dev
-            - libxslt1-dev
+            #- libxml2-dev
+            #- libxslt1-dev
             # elife-metrics
             - libffi-dev
             - libpq-dev


### PR DESCRIPTION
these now cause a state error in salt 3006